### PR TITLE
[NOW_FILE] add SCADA CSV ingest route

### DIFF
--- a/now_file_ingestor/Dockerfile
+++ b/now_file_ingestor/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/now_file_ingestor/main.py
+++ b/now_file_ingestor/main.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import os
+import uuid
+from typing import List
+
+import asyncpg
+import pandas as pd
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from loguru import logger
+from prometheus_fastapi_instrumentator import Instrumentator
+
+from .utils import parse_scada_csv, validate_hourly_sequence
+
+app = FastAPI(title="Genio NOW File Ingestor")
+Instrumentator().instrument(app).expose(app)
+
+PGHOST = os.getenv("PGHOST", "postgres")
+PGPORT = int(os.getenv("PGPORT", "5432"))
+PGUSER = os.getenv("PGUSER", "user")
+PGPASSWORD = os.getenv("PGPASSWORD", "password")
+PGDATABASE = os.getenv("PGDATABASE", "database")
+JZ_WELL_ID = os.getenv("JZ_WELL_ID", "11111111-1111-1111-1111-111111111111")
+
+pool: asyncpg.Pool | None = None
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    global pool
+    pool = await asyncpg.create_pool(
+        host=PGHOST,
+        port=PGPORT,
+        user=PGUSER,
+        password=PGPASSWORD,
+        database=PGDATABASE,
+    )
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS scada_records (
+                id SERIAL PRIMARY KEY,
+                well_id UUID NOT NULL,
+                timestamp TIMESTAMPTZ NOT NULL,
+                flow_rate DOUBLE PRECISION,
+                pressure DOUBLE PRECISION,
+                temperature DOUBLE PRECISION,
+                volume DOUBLE PRECISION
+            )
+            """
+        )
+    logger.info("[NOW_FILE] Database initialized")
+
+
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    if pool:
+        await pool.close()
+
+
+@app.post("/ingest/scada")
+async def ingest_scada_csv(file: UploadFile = File(...)) -> dict[str, int]:
+    if not file.filename.lower().endswith(".csv"):
+        raise HTTPException(status_code=400, detail="CSV file required")
+
+    contents = await file.read()
+    try:
+        df = parse_scada_csv(contents)
+    except Exception as exc:  # pragma: no cover - parse errors
+        logger.error(f"[NOW_FILE] Parse error: {exc}")
+        raise HTTPException(status_code=400, detail="Invalid CSV") from exc
+
+    if len(df) != 8772:
+        raise HTTPException(status_code=400, detail="Invalid row count")
+
+    validate_hourly_sequence(df["timestamp"])
+
+    records: List[tuple] = [
+        (
+            uuid.UUID(JZ_WELL_ID),
+            pd.to_datetime(row.timestamp).to_pydatetime(),
+            float(row.flow_rate),
+            float(row.pressure),
+            float(row.temperature),
+            float(row.volume),
+        )
+        for row in df.itertuples(index=False)
+    ]
+
+    assert pool is not None
+    async with pool.acquire() as conn:
+        await conn.executemany(
+            """
+            INSERT INTO scada_records (
+                well_id, timestamp, flow_rate, pressure, temperature, volume
+            ) VALUES ($1, $2, $3, $4, $5, $6)
+            """,
+            records,
+        )
+
+    return {"rows_inserted": len(records)}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual start
+    import uvicorn
+
+    uvicorn.run("main:app", host="0.0.0.0", port=8000)

--- a/now_file_ingestor/requirements.txt
+++ b/now_file_ingestor/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn[standard]
+loguru
+prometheus-fastapi-instrumentator
+asyncpg
+python-multipart
+pandas

--- a/now_file_ingestor/tests/test_utils.py
+++ b/now_file_ingestor/tests/test_utils.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import types
+import importlib
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, ROOT)
+
+import pytest
+
+from now_file_ingestor.utils import parse_scada_csv, validate_hourly_sequence
+
+
+def get_pandas():
+    if isinstance(sys.modules.get("pandas"), types.SimpleNamespace):
+        del sys.modules["pandas"]
+    return importlib.import_module("pandas")
+
+
+def test_parse_scada_csv_missing_columns():
+    data = b"timestamp,flow_rate\n2024-01-01T00:00Z,1.0"
+    with pytest.raises(ValueError):
+        parse_scada_csv(data)
+
+
+def test_validate_hourly_sequence_success():
+    pd = get_pandas()
+    df = pd.DataFrame({"timestamp": pd.date_range("2024-01-01", periods=3, freq="H")})
+    validate_hourly_sequence(df["timestamp"])
+
+
+def test_validate_hourly_sequence_failure():
+    pd = get_pandas()
+    df = pd.DataFrame({"timestamp": ["2024-01-01 00:00", "2024-01-01 02:00"]})
+    with pytest.raises(ValueError):
+        validate_hourly_sequence(df["timestamp"])

--- a/now_file_ingestor/utils.py
+++ b/now_file_ingestor/utils.py
@@ -1,0 +1,24 @@
+import io
+from datetime import timedelta
+from typing import Iterable
+
+import pandas as pd
+
+REQUIRED_COLUMNS = {"timestamp", "flow_rate", "pressure", "temperature", "volume"}
+
+
+def parse_scada_csv(contents: bytes) -> pd.DataFrame:
+    """Parse SCADA CSV bytes and ensure required columns are present."""
+    df = pd.read_csv(io.BytesIO(contents))
+    missing = REQUIRED_COLUMNS - set(df.columns)
+    if missing:
+        raise ValueError(f"Missing columns: {', '.join(sorted(missing))}")
+    return df
+
+
+def validate_hourly_sequence(timestamps: Iterable) -> None:
+    """Validate timestamps are hourly and sequential."""
+    times = pd.to_datetime(list(timestamps))
+    diffs = times.diff().dropna()
+    if not (diffs == timedelta(hours=1)).all():
+        raise ValueError("Timestamps must be hourly and sequential")


### PR DESCRIPTION
## Summary
- add new `now_file_ingestor` service
- include SCADA CSV ingestion route using asyncpg
- validate hourly timestamps and prepare DB insert
- test CSV parsing utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d910270bc8332bf179b3c1cac260a