### PR TITLE
[EMBED] finalize memory capture listener

### DIFF
--- a/embed_memory_service/main.py
+++ b/embed_memory_service/main.py
@@ -6,6 +6,9 @@ from schemas import EmbedRequest
 import redis.asyncio as redis
 from prometheus_fastapi_instrumentator import Instrumentator
 from prometheus_client import Histogram, Counter
+from qdrant_client.http import models as qm
+import psycopg2
+import uuid
 import asyncio
 import json
 import os
@@ -23,6 +26,7 @@ REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
 REDIS_PORT = int(os.getenv("REDIS_PORT", 6379))
 VISUALIZE_CHANNEL = os.getenv("VISUALIZE_CHANNEL", "visualize_channel")
 EMBED_CHANNEL = os.getenv("EMBED_CHANNEL", "embed_channel")
+REPLAY_CHANNEL = os.getenv("REPLAY_CHANNEL", "replay_channel")
 
 redis_pool = redis.ConnectionPool.from_url(
     f"redis://{REDIS_HOST}:{REDIS_PORT}/0", decode_responses=True
@@ -36,10 +40,115 @@ embed_errors = Counter("embed_errors_total", "Total errors in Embed Memory servi
 shutdown_event = asyncio.Event()
 
 
+def pg_connect() -> psycopg2.extensions.connection:
+    """Return a new PostgreSQL connection using environment variables."""
+    return psycopg2.connect(
+        host=os.getenv("PGHOST", "postgres"),
+        port=os.getenv("PGPORT", 5432),
+        user=os.getenv("PGUSER", "user"),
+        password=os.getenv("PGPASSWORD", "password"),
+        dbname=os.getenv("PGDATABASE", "database"),
+    )
+
+
+def prepare_entries(points: list[qm.PointStruct]) -> list[tuple]:
+    """Convert Qdrant points to tuples for DB insertion."""
+    entries: list[tuple] = []
+    for point in points:
+        meta = point.payload or {}
+        entries.append(
+            (
+                str(uuid.uuid4()),
+                meta.get("well_id"),
+                meta.get("source"),
+                meta.get("timestamp") or meta.get("page"),
+                meta.get("text"),
+                meta.get("noun_phrases", []),
+                meta.get("anomaly") or meta.get("important", False),
+                str(point.id),
+                meta.get("loop_stage"),
+                meta.get("source_file"),
+            )
+        )
+    return entries
+
+
+def store_to_memory_log(points: list[qm.PointStruct]) -> None:
+    """Persist points into the memory_log table."""
+    if not points:
+        return
+    conn = pg_connect()
+    try:
+        with conn.cursor() as cur:
+            cur.executemany(
+                """
+                INSERT INTO memory_log (
+                    memory_id, well_id, source, timestamp_or_page,
+                    text, noun_phrases, anomaly_or_importance,
+                    vector_id, loop_stage, source_file
+                ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                """,
+                prepare_entries(points),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def mark_embedded(ids: list[str]) -> None:
+    """Update Qdrant payload loop_stage to 'embedded'."""
+    if not ids or not db.qdrant:
+        return
+    db.qdrant.set_payload(
+        collection_name="genio_memory",
+        payload={"loop_stage": "embedded"},
+        points=ids,
+    )
+
+
+async def fetch_truth_points(well_id: str) -> list[qm.PointStruct]:
+    """Retrieve all truth-stage points for a well from Qdrant."""
+    if not db.qdrant:
+        return []
+    filt = qm.Filter(
+        must=[
+            qm.FieldCondition(key="well_id", match=qm.MatchValue(value=well_id)),
+            qm.FieldCondition(key="loop_stage", match=qm.MatchValue(value="truth")),
+        ]
+    )
+    points: list[qm.PointStruct] = []
+    offset = None
+    while True:
+        batch, offset = await asyncio.to_thread(
+            db.qdrant.scroll,
+            collection_name="genio_memory",
+            scroll_filter=filt,
+            limit=100,
+            offset=offset,
+        )
+        points.extend(batch)
+        if offset is None:
+            break
+    return points
+
+
+async def handle_embed_ready(well_id: str, source: str) -> None:
+    """Process an embed_ready event for a given well."""
+    points = await fetch_truth_points(well_id)
+    store_to_memory_log(points)
+    mark_embedded([str(p.id) for p in points])
+    await redis_client.publish(
+        REPLAY_CHANNEL,
+        json.dumps({"event": "replay_ready", "well_id": well_id, "source": source}),
+    )
+    logger.info("[EMBED] Finalized %d embeddings for well %s", len(points), well_id)
+
+
 @app.on_event("startup")
 async def startup():
     await db.connect()
     asyncio.create_task(redis_listener())
+    asyncio.create_task(embed_ready_listener())
 
 
 @app.on_event("shutdown")
@@ -118,6 +227,26 @@ async def handle_embedding(data):
     except Exception as e:
         embed_errors.inc()
         logger.error("[EMBED] Error storing embedding", uuid=uuid, error=str(e))
+
+
+async def embed_ready_listener():
+    """Listen for embed_ready events and finalize memory capture."""
+    pubsub = redis_client.pubsub()
+    await pubsub.subscribe(EMBED_CHANNEL)
+    logger.info(f"[EMBED] Subscribed to '{EMBED_CHANNEL}'")
+    while not shutdown_event.is_set():
+        message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1)
+        if not message:
+            continue
+        try:
+            data = json.loads(message["data"])
+            if data.get("event") != "embed_ready":
+                continue
+            well_id = data["well_id"]
+            source = data.get("source", "unknown")
+            await handle_embed_ready(well_id, source)
+        except Exception as exc:
+            logger.error(f"[EMBED] Failed to process embed_ready: {exc}")
 
 
 if __name__ == "__main__":

--- a/embed_memory_service/tests/test_prepare_entries.py
+++ b/embed_memory_service/tests/test_prepare_entries.py
@@ -1,0 +1,35 @@
+import sys
+import os
+from types import SimpleNamespace
+
+SERVICE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, SERVICE_DIR)
+
+from main import prepare_entries
+
+
+def test_prepare_entries():
+    point = SimpleNamespace(
+        id="123",
+        payload={
+            "well_id": "w1",
+            "source": "scada",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "text": "hello",
+            "noun_phrases": ["hello"],
+            "anomaly": True,
+            "loop_stage": "truth",
+            "source_file": "f.txt",
+        },
+    )
+    entries = prepare_entries([point])
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry[1] == "w1"
+    assert entry[2] == "scada"
+    assert entry[3] == "2024-01-01T00:00:00Z"
+    assert entry[4] == "hello"
+    assert entry[5] == ["hello"]
+    assert entry[6] is True
+    assert entry[7] == "123"
+    assert entry[8] == "truth"


### PR DESCRIPTION
## Summary
- add `embed_ready` listener for SCADA and WELLFILE sources
- persist `truth` stage vectors into `memory_log` in Postgres
- mark embedded vectors in Qdrant and notify replay service
- unit test tuple preparation for DB insert

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ed22b04248332adb0ce568f5a0831