### PR TITLE
[REPLAY][VIEW] semantic replay api

### DIFF
--- a/memory_replay_viewer_service/main.py
+++ b/memory_replay_viewer_service/main.py
@@ -3,11 +3,25 @@ from fastapi.responses import HTMLResponse
 from fastapi.middleware.cors import CORSMiddleware
 from shared.redis_utils import subscribe
 from shared.logger import logger
+from shared.config import QDRANT_HOST, QDRANT_PORT
+from sentence_transformers import SentenceTransformer
+from qdrant_client import QdrantClient
+from qdrant_client.http.models import Filter, FieldCondition, MatchValue
+import openai
+import os
 import threading
 import json
 
 app = FastAPI()
 latest_replays = []
+
+MODEL_NAME = "all-MiniLM-L6-v2"
+model = SentenceTransformer(MODEL_NAME)
+qdrant_client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+COLLECTION = "genio_memory"
+
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
 app.add_middleware(
     CORSMiddleware,
@@ -16,6 +30,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
 
 def listener():
     try:
@@ -31,9 +46,11 @@ def listener():
     except Exception as e:
         logger.error(f"[VIEWER] Listener failed: {e}")
 
+
 @app.on_event("startup")
 def start_listener_thread():
     threading.Thread(target=listener, daemon=True).start()
+
 
 @app.get("/", response_class=HTMLResponse)
 def view_replays():
@@ -43,6 +60,7 @@ def view_replays():
     html += "</ul>"
     return html
 
+
 @app.get("/memory/replay")
 def get_latest_replays():
     """
@@ -50,6 +68,38 @@ def get_latest_replays():
     """
     logger.info(f"[VIEWER] Serving {len(latest_replays)} replays")
     return list(reversed(latest_replays))  # newest first
+
+
+@app.post("/chat")
+async def chat(query: str, well_id: str):
+    """Answer questions using memory context from Qdrant."""
+    vector = model.encode(query).tolist()
+    results = qdrant_client.search(
+        collection_name=COLLECTION,
+        query_vector=vector,
+        limit=5,
+        query_filter=Filter(
+            must=[FieldCondition(key="well_id", match=MatchValue(value=well_id))]
+        ),
+    )
+    context_lines = [
+        f"Memory {i+1}: \"{r.payload.get('text','')}\"" for i, r in enumerate(results)
+    ]
+    prompt = "Context:\n\n" + "\n\n".join(context_lines)
+    prompt += f'\n\nQuestion: "{query}"\nAnswer:'
+    openai.api_key = OPENAI_API_KEY
+    try:
+        completion = openai.ChatCompletion.create(
+            model=OPENAI_MODEL,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        answer = completion.choices[0].message["content"].strip()
+    except Exception as e:  # pragma: no cover - openai may fail
+        logger.error(f"[VIEWER] OpenAI call failed: {e}")
+        answer = "Error generating answer"
+    excerpts = [r.payload.get("text") for r in results]
+    return {"answer": answer, "sources": excerpts}
+
 
 @app.get("/health")
 def health():

--- a/memory_replay_viewer_service/tests/test_chat.py
+++ b/memory_replay_viewer_service/tests/test_chat.py
@@ -1,0 +1,50 @@
+import sys
+import types
+import os
+from fastapi.testclient import TestClient
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, ROOT)
+
+# Lightweight mocks
+sys.modules["sentence_transformers"] = types.SimpleNamespace(
+    SentenceTransformer=lambda *args, **kwargs: None
+)
+sys.modules["openai"] = types.SimpleNamespace(
+    ChatCompletion=types.SimpleNamespace(create=lambda **kw: None)
+)
+sys.modules["shared.redis_utils"] = types.SimpleNamespace(
+    subscribe=lambda *a, **k: types.SimpleNamespace(listen=lambda: []),
+    publish=lambda *a, **k: None,
+)
+
+from memory_replay_viewer_service import main
+
+client = TestClient(main.app)
+
+
+def test_chat_route():
+    class Enc:
+        def __init__(self, v):
+            self.v = v
+
+        def tolist(self):
+            return self.v
+
+    main.model = types.SimpleNamespace(encode=lambda x: Enc([0.1]))
+    main.qdrant_client = types.SimpleNamespace(
+        search=lambda **kwargs: [
+            types.SimpleNamespace(payload={"text": "context"}, id="1")
+        ]
+    )
+    main.OPENAI_API_KEY = "test"
+
+    class Dummy:
+        choices = [types.SimpleNamespace(message={"content": "answer"})]
+
+    main.openai = types.SimpleNamespace(
+        ChatCompletion=types.SimpleNamespace(create=lambda **kw: Dummy())
+    )
+    resp = client.post("/chat", params={"query": "q", "well_id": "w"})
+    assert resp.status_code == 200
+    assert resp.json()["answer"] == "answer"

--- a/replay_memory_service/main.py
+++ b/replay_memory_service/main.py
@@ -1,11 +1,50 @@
 from fastapi import FastAPI
 from shared.redis_utils import subscribe, publish
 from shared.logger import logger
-import threading, json, time
+from shared.config import (
+    QDRANT_HOST,
+    QDRANT_PORT,
+    PGHOST,
+    PGPORT,
+    PGUSER,
+    PGPASSWORD,
+    PGDATABASE,
+)
+import threading
+import json
+import time
 import os
+import asyncpg
+from sentence_transformers import SentenceTransformer
+from qdrant_client import QdrantClient
+from qdrant_client.http.models import Filter, FieldCondition, MatchValue
 
 app = FastAPI()
+
+MODEL_NAME = "all-MiniLM-L6-v2"
+model = SentenceTransformer(MODEL_NAME)
+qdrant_client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+COLLECTION = "genio_memory"
+
+DATABASE_URL = f"postgresql://{PGUSER}:{PGPASSWORD}@{PGHOST}:{PGPORT}/{PGDATABASE}"
+pg_pool: asyncpg.Pool | None = None
+
 MEMORY_LOG = "/app/memory_log.jsonl"
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    """Initialize PostgreSQL connection pool."""
+    global pg_pool
+    pg_pool = await asyncpg.create_pool(DATABASE_URL)
+
+
+@app.on_event("shutdown")
+async def on_shutdown() -> None:
+    """Close PostgreSQL connection pool."""
+    if pg_pool:
+        await pg_pool.close()
+
 
 def load_memory(filter_truth=True):
     if not os.path.exists(MEMORY_LOG):
@@ -15,6 +54,7 @@ def load_memory(filter_truth=True):
     if filter_truth:
         return [e for e in entries if e.get("truth") is True]
     return entries
+
 
 def listener():
     pubsub = subscribe("replay_channel")
@@ -34,12 +74,57 @@ def listener():
             except Exception as e:
                 logger.error(f"[REPLAY] Error processing message: {e}")
 
+
 threading.Thread(target=listener, daemon=True).start()
+
+
+@app.get("/replay/search")
+def search_memory(query: str, well_id: str, top_k: int = 5):
+    """Perform semantic search across stored memory vectors."""
+    vector = model.encode(query).tolist()
+    results = qdrant_client.search(
+        collection_name=COLLECTION,
+        query_vector=vector,
+        limit=top_k,
+        query_filter=Filter(
+            must=[FieldCondition(key="well_id", match=MatchValue(value=well_id))]
+        ),
+    )
+    return [
+        {
+            "text": r.payload.get("text"),
+            "source": r.payload.get("source"),
+            "timestamp_or_page": r.payload.get("timestamp", r.payload.get("page")),
+            "anomaly_or_importance": r.payload.get(
+                "anomaly", r.payload.get("important", False)
+            ),
+            "vector_id": r.id,
+        }
+        for r in results
+    ]
+
+
+@app.get("/replay/timeline")
+async def replay_timeline(well_id: str, source: str | None = None):
+    """Return chronological replay of memory events for a well."""
+    assert pg_pool is not None
+    query = "SELECT text, timestamp_or_page, anomaly_or_importance, loop_stage, vector_id FROM memory_log WHERE well_id=$1"
+    params = [well_id]
+    if source:
+        query += " AND source=$2"
+        params.append(source)
+    query += " ORDER BY timestamp_or_page"
+    async with pg_pool.acquire() as conn:
+        rows = await conn.fetch(query, *params)
+    return [dict(row) for row in rows]
+
 
 @app.get("/")
 def healthcheck():
     return {"status": "replay_memory_service active"}
 
+
 import uvicorn
+
 if __name__ == "__main__":
     uvicorn.run("main:app", host="0.0.0.0", port=8000)

--- a/replay_memory_service/tests/test_routes.py
+++ b/replay_memory_service/tests/test_routes.py
@@ -1,0 +1,81 @@
+import sys
+import types
+import os
+from fastapi.testclient import TestClient
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, ROOT)
+
+# Avoid heavy imports for sentence_transformers
+sys.modules["sentence_transformers"] = types.SimpleNamespace(
+    SentenceTransformer=lambda *args, **kwargs: None
+)
+sys.modules["shared.redis_utils"] = types.SimpleNamespace(
+    subscribe=lambda *a, **k: types.SimpleNamespace(listen=lambda: []),
+    publish=lambda *a, **k: None,
+)
+
+from replay_memory_service import main
+
+client = TestClient(main.app)
+
+
+def test_search_memory():
+    # Mock model.encode and qdrant_client.search
+    class Enc:
+        def __init__(self, v):
+            self.v = v
+
+        def tolist(self):
+            return self.v
+
+    main.model = types.SimpleNamespace(encode=lambda x: Enc([0.1, 0.2]))
+    main.qdrant_client = types.SimpleNamespace(
+        search=lambda **kwargs: [
+            types.SimpleNamespace(
+                payload={
+                    "text": "test",
+                    "source": "s",
+                    "timestamp": "t",
+                    "anomaly": False,
+                },
+                id="1",
+            )
+        ]
+    )
+    resp = client.get("/replay/search", params={"query": "q", "well_id": "w"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["vector_id"] == "1"
+
+
+def test_replay_timeline():
+    async def fetch(query, *params):
+        return [
+            {
+                "text": "t",
+                "timestamp_or_page": "p",
+                "anomaly_or_importance": False,
+                "loop_stage": "ls",
+                "vector_id": "v",
+            }
+        ]
+
+    class Conn:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def fetch(self, query, *params):
+            return await fetch(query, *params)
+
+    class Pool:
+        def acquire(self):
+            return Conn()
+
+    main.pg_pool = Pool()
+    resp = client.get("/replay/timeline", params={"well_id": "w"})
+    assert resp.status_code == 200
+    assert resp.json()[0]["vector_id"] == "v"


### PR DESCRIPTION
## Summary
- add Qdrant-powered search and timeline routes to replay_memory_service
- implement LLM chat endpoint in memory_replay_viewer_service
- include unit tests for new endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ed26ff7c08332a38e856c512f73bc