### PR TITLE
[NOW] Extend file ingestor

### DIFF
--- a/now_file_ingestor/tests/test_ingest_route.py
+++ b/now_file_ingestor/tests/test_ingest_route.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import types
+
+from fastapi.testclient import TestClient
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, ROOT)
+
+
+dummy_requests = types.ModuleType("requests")
+dummy_requests.post = lambda *args, **kwargs: None
+sys.modules["requests"] = dummy_requests
+
+from now_file_ingestor.main import app
+
+
+def _prepare_app():
+    app.router.on_startup.clear()
+    app.router.on_shutdown.clear()
+
+
+class DummyRedis:
+    def __init__(self):
+        self.published = []
+
+    def publish(self, channel: str, message: str) -> None:
+        self.published.append((channel, message))
+
+
+def test_ingest_file(tmp_path, monkeypatch):
+    _prepare_app()
+    dummy = DummyRedis()
+    monkeypatch.setattr("now_file_ingestor.main.redis_client", dummy)
+    monkeypatch.setattr("now_file_ingestor.main.RAW_DATA_ROOT", str(tmp_path))
+
+    client = TestClient(app)
+    resp = client.post(
+        "/ingest",
+        data={"well_id": "w1"},
+        files={"file": ("data.csv", "x,y\n1,2", "text/csv")},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert os.path.exists(data["file_path"])
+    assert dummy.published
+    assert dummy.published[0][0] == "file_ingest"

--- a/now_file_ingestor/tests/test_utils.py
+++ b/now_file_ingestor/tests/test_utils.py
@@ -8,11 +8,16 @@ sys.path.insert(0, ROOT)
 
 import pytest
 
-from now_file_ingestor.utils import parse_scada_csv, validate_hourly_sequence
+from now_file_ingestor.utils import (
+    parse_scada_csv,
+    validate_hourly_sequence,
+    classify_filename,
+    generate_file_path,
+)
 
 
 def get_pandas():
-    if isinstance(sys.modules.get("pandas"), types.SimpleNamespace):
+    if "pandas" in sys.modules:
         del sys.modules["pandas"]
     return importlib.import_module("pandas")
 
@@ -34,3 +39,15 @@ def test_validate_hourly_sequence_failure():
     df = pd.DataFrame({"timestamp": ["2024-01-01 00:00", "2024-01-01 02:00"]})
     with pytest.raises(ValueError):
         validate_hourly_sequence(df["timestamp"])
+
+
+def test_classify_filename():
+    assert classify_filename("test.csv") == "scada"
+    assert classify_filename("something.PDF") == "wellfile"
+    with pytest.raises(ValueError):
+        classify_filename("other.txt")
+
+
+def test_generate_file_path(tmp_path):
+    path = generate_file_path(str(tmp_path), "well1", "scada", "x.csv")
+    assert path.startswith(os.path.join(str(tmp_path), "well1", "scada"))

--- a/now_file_ingestor/utils.py
+++ b/now_file_ingestor/utils.py
@@ -1,5 +1,7 @@
 import io
-from datetime import timedelta
+import os
+import uuid
+from datetime import datetime, timedelta
 from typing import Iterable
 
 import pandas as pd
@@ -22,3 +24,21 @@ def validate_hourly_sequence(timestamps: Iterable) -> None:
     diffs = times.diff().dropna()
     if not (diffs == timedelta(hours=1)).all():
         raise ValueError("Timestamps must be hourly and sequential")
+
+
+def classify_filename(filename: str) -> str:
+    """Return logical file type based on extension."""
+    ext = os.path.splitext(filename.lower())[1]
+    if ext == ".csv":
+        return "scada"
+    if ext == ".pdf":
+        return "wellfile"
+    raise ValueError("Unsupported file type")
+
+
+def generate_file_path(root: str, well_id: str, file_type: str, filename: str) -> str:
+    """Return destination path for a new upload."""
+    ts = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+    dest_dir = os.path.join(root, well_id, file_type)
+    os.makedirs(dest_dir, exist_ok=True)
+    return os.path.join(dest_dir, f"{ts}_{uuid.uuid4()}_{filename}")

--- a/reflect_service/processor.py
+++ b/reflect_service/processor.py
@@ -1,7 +1,7 @@
 import json
 import os
 import threading
-from typing import List
+from typing import List, Any
 
 import pandas as pd
 import psycopg2
@@ -24,7 +24,7 @@ KEYWORDS = ["lease", "permit", "inspection", "abandonment", "test"]
 stop_event = threading.Event()
 
 
-def get_db_connection() -> psycopg2.extensions.connection:
+def get_db_connection() -> Any:
     """Create a new PostgreSQL connection."""
 
     return psycopg2.connect(

--- a/truth_service/main.py
+++ b/truth_service/main.py
@@ -40,7 +40,7 @@ def embed_text(text: str) -> List[float]:
     return model.encode(text).tolist()
 
 
-def fetch_rows(cursor: psycopg2.extensions.cursor, table: str) -> List[Tuple[Any, ...]]:
+def fetch_rows(cursor: Any, table: str) -> List[Tuple[Any, ...]]:
     cursor.execute(
         f"SELECT id, well_id, timestamp, text, noun_phrases, anomaly, source_file FROM {table} WHERE embedded = false LIMIT %s",
         (BATCH_SIZE,),
@@ -48,7 +48,7 @@ def fetch_rows(cursor: psycopg2.extensions.cursor, table: str) -> List[Tuple[Any
     return cursor.fetchall()
 
 
-def fetch_wellfile(cursor: psycopg2.extensions.cursor) -> List[Tuple[Any, ...]]:
+def fetch_wellfile(cursor: Any) -> List[Tuple[Any, ...]]:
     cursor.execute(
         "SELECT id, well_id, page, text, noun_phrases, important, source_file FROM reflected_wellfile WHERE embedded = false LIMIT %s",
         (BATCH_SIZE,),
@@ -56,9 +56,7 @@ def fetch_wellfile(cursor: psycopg2.extensions.cursor) -> List[Tuple[Any, ...]]:
     return cursor.fetchall()
 
 
-def mark_embedded(
-    cursor: psycopg2.extensions.cursor, table: str, ids: List[Any]
-) -> None:
+def mark_embedded(cursor: Any, table: str, ids: List[Any]) -> None:
     cursor.execute(
         f"UPDATE {table} SET embedded = true WHERE id = ANY(%s)",
         (ids,),
@@ -69,7 +67,7 @@ def upsert_points(points: List[PointStruct]) -> None:
     qdrant.upsert(collection_name=QDRANT_COLLECTION, points=points)
 
 
-def embed_reflected_scada(conn: psycopg2.extensions.connection) -> None:
+def embed_reflected_scada(conn: Any) -> None:
     with conn.cursor() as cur:
         rows = fetch_rows(cur, "reflected_scada")
         if not rows:
@@ -104,7 +102,7 @@ def embed_reflected_scada(conn: psycopg2.extensions.connection) -> None:
         )
 
 
-def embed_reflected_wellfile(conn: psycopg2.extensions.connection) -> None:
+def embed_reflected_wellfile(conn: Any) -> None:
     with conn.cursor() as cur:
         rows = fetch_wellfile(cur)
         if not rows:


### PR DESCRIPTION
## Summary
- implement redis-backed file ingestion endpoint
- classify uploads as SCADA or wellfile
- store uploads under configurable directory
- emit redis events and optional webhooks
- improve noun phrase extraction fallback logic
- adjust reflect/truth services to avoid type hints that break tests
- add route tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68503be561c08332b7a15261328fc469