### PR TITLE
[EXPRESS] snapshot emission

### DIFF
--- a/express_emitter/requirements.txt
+++ b/express_emitter/requirements.txt
@@ -7,3 +7,5 @@ prometheus-fastapi-instrumentator
 pandas
 PyMuPDF
 psycopg2-binary
+httpx
+paddleocr

--- a/express_emitter/tests/test_ingest_utils.py
+++ b/express_emitter/tests/test_ingest_utils.py
@@ -2,7 +2,12 @@ import os
 import tempfile
 import pandas as pd
 import fitz
-from express_emitter.main import parse_scada_csv, parse_wellfile_pdf
+from express_emitter.main import (
+    parse_scada_csv,
+    parse_wellfile_pdf,
+    scada_rows_to_snapshots,
+    wellfile_rows_to_snapshots,
+)
 from now_ingestor.scada_utils import parse_scada_timestamp
 
 
@@ -17,7 +22,7 @@ def test_parse_scada_csv():
             "volume_mcf": [4.0],
         })
         df.to_csv(path, index=False)
-        rows = parse_scada_csv(path, "11111111-1111-1111-1111-111111111111")
+        rows = list(parse_scada_csv(path, "11111111-1111-1111-1111-111111111111"))
         assert len(rows) == 1
         row = rows[0]
         assert row["flow_rate"] == 5.0
@@ -25,6 +30,12 @@ def test_parse_scada_csv():
         assert row["temperature"] == 3.0
         assert row["volume"] == 4.0
         assert row["timestamp"] == parse_scada_timestamp("05/07/2024 00:00-01:00")
+
+        snaps = scada_rows_to_snapshots(rows)
+        assert len(snaps) == 1
+        snap = snaps[0]
+        assert snap["source"] == "scada"
+        assert snap["well_id"] == "11111111-1111-1111-1111-111111111111"
 
 
 def test_parse_wellfile_pdf(tmp_path):
@@ -36,4 +47,8 @@ def test_parse_wellfile_pdf(tmp_path):
     doc.close()
     rows = parse_wellfile_pdf(str(pdf_path), "abcd")
     assert rows
-    assert all(len(r["text"]) >= 15 for r in rows)
+    assert len(rows) == 1
+    assert "First" in rows[0]["text"]
+
+    snaps = wellfile_rows_to_snapshots(rows, "abcd")
+    assert snaps[0]["source"] == "wellfile"

--- a/interpret_service/tests/test_extract_noun_phrases.py
+++ b/interpret_service/tests/test_extract_noun_phrases.py
@@ -1,8 +1,25 @@
 import sys
 import os
+import types
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, ROOT)
+
+nlp_module = types.ModuleType("spacy")
+
+class DummyNLP:
+    def __call__(self, text: str):
+        return types.SimpleNamespace(
+            noun_chunks=[
+                types.SimpleNamespace(text="Pressure"),
+                types.SimpleNamespace(text="88 psi"),
+                types.SimpleNamespace(text="noon"),
+            ],
+            sents=[types.SimpleNamespace(text=text.split(".")[0] + ".")],
+        )
+
+nlp_module.load = lambda *a, **k: DummyNLP()
+sys.modules["spacy"] = nlp_module
 
 from interpret_service.interpret_worker import extract_noun_phrases
 

--- a/reflect_service/tests/test_processor.py
+++ b/reflect_service/tests/test_processor.py
@@ -8,6 +8,12 @@ if isinstance(sys.modules.get("pandas"), types.SimpleNamespace):
     del sys.modules["pandas"]
 pd = importlib.import_module("pandas")
 
+# Stub psycopg2 for offline testing
+dummy_psycopg2 = types.ModuleType("psycopg2")
+dummy_psycopg2.extras = types.SimpleNamespace(execute_batch=lambda *a, **k: None)
+dummy_psycopg2.extensions = types.SimpleNamespace(connection=object)
+sys.modules["psycopg2"] = dummy_psycopg2
+
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, ROOT)
 

--- a/truth_service/tests/test_embedder.py
+++ b/truth_service/tests/test_embedder.py
@@ -28,7 +28,13 @@ module.__spec__ = importlib.machinery.ModuleSpec("pandas", loader=None)
 module.Series = dict
 sys.modules["pandas"] = module
 
+# Stub psycopg2 extensions
+dummy_pg = types.ModuleType("psycopg2")
+dummy_pg.extensions = types.SimpleNamespace(cursor=object, connection=object)
+sys.modules["psycopg2"] = dummy_pg
+
 from truth_service.main import embed_text
+sys.modules.pop("pandas", None)
 
 
 def test_embed_text_dimension():


### PR DESCRIPTION
## Summary
- parse SCADA CSV row by row and build snapshot helpers
- extract first sentence per PDF page with optional OCR
- post parsed snapshots to interpret service and log counts
- expand ingest utility tests for snapshot helpers
- stub heavy dependencies in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68503bfa35bc8332bd5ea9cab7a49b6a