### PR TITLE
[TRUTH] Add OpenAI embedding option

### DIFF
--- a/reflect_service/processor.py
+++ b/reflect_service/processor.py
@@ -1,7 +1,7 @@
 import json
 import os
 import threading
-from typing import List
+from typing import List, Any
 
 import pandas as pd
 import psycopg2
@@ -24,7 +24,7 @@ KEYWORDS = ["lease", "permit", "inspection", "abandonment", "test"]
 stop_event = threading.Event()
 
 
-def get_db_connection() -> psycopg2.extensions.connection:
+def get_db_connection() -> Any:
     """Create a new PostgreSQL connection."""
 
     return psycopg2.connect(

--- a/truth_service/main.py
+++ b/truth_service/main.py
@@ -8,7 +8,20 @@ import psycopg2
 import redis
 from qdrant_client import QdrantClient
 from qdrant_client.http.models import PointStruct
-from sentence_transformers import SentenceTransformer
+from shared.logger import logger
+
+USE_OPENAI_EMBEDDING = os.getenv("USE_OPENAI_EMBEDDING", "false").lower() == "true"
+
+if USE_OPENAI_EMBEDDING:
+    import openai  # type: ignore
+
+    MODEL_NAME = "text-embedding-3-small"
+    OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+else:
+    from sentence_transformers import SentenceTransformer
+
+    MODEL_NAME = os.getenv("MODEL_NAME", "all-MiniLM-L6-v2")
+    model = SentenceTransformer(MODEL_NAME)
 
 
 REDIS_HOST = os.getenv("REDIS_HOST", "genio_redis")
@@ -30,14 +43,24 @@ QDRANT_COLLECTION = os.getenv("QDRANT_COLLECTION", "genio_memory")
 BATCH_SIZE = int(os.getenv("BATCH_SIZE", "100"))
 
 
-model = SentenceTransformer("all-MiniLM-L6-v2")
 redis_client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
 qdrant = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
 
 
 def embed_text(text: str) -> List[float]:
-    """Return 384-dim embedding for provided text."""
-    return model.encode(text).tolist()
+    """Return embedding for provided text using configured model."""
+    if USE_OPENAI_EMBEDDING:
+        openai.api_key = OPENAI_API_KEY
+        try:
+            resp = openai.Embedding.create(model=MODEL_NAME, input=text)
+            vector = resp["data"][0]["embedding"]
+        except Exception as exc:  # pragma: no cover - network issues
+            logger.error("[TRUTH] OpenAI embedding failed: %s", exc)
+            vector = []
+    else:
+        vector = model.encode(text).tolist()
+    logger.info("[TRUTH] Embedded text using %s", MODEL_NAME)
+    return vector
 
 
 def fetch_rows(cursor: psycopg2.extensions.cursor, table: str) -> List[Tuple[Any, ...]]:
@@ -65,8 +88,28 @@ def mark_embedded(
     )
 
 
-def upsert_points(points: List[PointStruct]) -> None:
-    qdrant.upsert(collection_name=QDRANT_COLLECTION, points=points)
+def upsert_points(points: List[PointStruct]) -> bool:
+    """Insert points into Qdrant and return success flag."""
+    try:
+        qdrant.upsert(collection_name=QDRANT_COLLECTION, points=points)
+        logger.info("[TRUTH] Upserted %d vectors", len(points))
+        return True
+    except Exception as exc:  # pragma: no cover - qdrant may be unavailable
+        logger.error("[TRUTH] Qdrant upsert failed: %s", exc)
+        return False
+
+
+def store_sentence(sentence: str, metadata: Dict[str, Any]) -> str:
+    """Embed a sentence and store it with metadata in Qdrant."""
+    vector = embed_text(sentence)
+    payload = metadata.copy()
+    payload["text"] = sentence
+    payload["loop_stage"] = "truth"
+    uid = str(uuid.uuid4())
+    point = PointStruct(id=uid, vector=vector, payload=payload)
+    success = upsert_points([point])
+    logger.info("[TRUTH] Model=%s insert_success=%s", MODEL_NAME, success)
+    return uid
 
 
 def embed_reflected_scada(conn: psycopg2.extensions.connection) -> None:
@@ -93,9 +136,10 @@ def embed_reflected_scada(conn: psycopg2.extensions.connection) -> None:
                 PointStruct(id=str(uuid.uuid4()), vector=vector, payload=payload)
             )
             ids.append(row_id)
-        upsert_points(points)
+        success = upsert_points(points)
         mark_embedded(cur, "reflected_scada", ids)
         conn.commit()
+        logger.info("[TRUTH] Insert success=%s for scada", success)
         redis_client.publish(
             EMBED_CHANNEL,
             json.dumps(
@@ -128,9 +172,10 @@ def embed_reflected_wellfile(conn: psycopg2.extensions.connection) -> None:
                 PointStruct(id=str(uuid.uuid4()), vector=vector, payload=payload)
             )
             ids.append(row_id)
-        upsert_points(points)
+        success = upsert_points(points)
         mark_embedded(cur, "reflected_wellfile", ids)
         conn.commit()
+        logger.info("[TRUTH] Insert success=%s for wellfile", success)
         redis_client.publish(
             EMBED_CHANNEL,
             json.dumps(

--- a/truth_service/requirements.txt
+++ b/truth_service/requirements.txt
@@ -2,3 +2,4 @@ psycopg2-binary
 redis[hiredis]
 qdrant-client
 sentence-transformers
+openai

--- a/truth_service/tests/test_embedder.py
+++ b/truth_service/tests/test_embedder.py
@@ -1,13 +1,21 @@
 import sys
 import os
 import types
-import importlib.machinery
+import importlib
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, ROOT)
 
+# ensure psycopg2 has expected attributes even if stubbed by other tests
+if "psycopg2" not in sys.modules:
+    sys.modules["psycopg2"] = types.ModuleType("psycopg2")
+if not hasattr(sys.modules["psycopg2"], "extensions"):
+    sys.modules["psycopg2"].extensions = types.SimpleNamespace(
+        cursor=object, connection=object
+    )
 
-# Stub sentence_transformers to avoid network downloads
+
+# stub sentence_transformers
 class DummyVector(list):
     def tolist(self):
         return list(self)
@@ -22,16 +30,40 @@ dummy_st = types.ModuleType("sentence_transformers")
 dummy_st.SentenceTransformer = lambda *args, **kwargs: DummyModel()
 sys.modules["sentence_transformers"] = dummy_st
 
-# Stub pandas for transformers import
-module = types.ModuleType("pandas")
+# stub pandas for transformers dependency
+module = types.SimpleNamespace()
 module.__spec__ = importlib.machinery.ModuleSpec("pandas", loader=None)
 module.Series = dict
 sys.modules["pandas"] = module
 
-from truth_service.main import embed_text
+
+def reload_truth():
+    if "truth_service.main" in sys.modules:
+        del sys.modules["truth_service.main"]
+    return importlib.import_module("truth_service.main")
 
 
 def test_embed_text_dimension():
-    vec = embed_text("hello world")
+    mod = reload_truth()
+    vec = mod.embed_text("hello world")
     assert isinstance(vec, list)
     assert len(vec) == 384
+
+
+def test_openai_embedding(monkeypatch):
+    os.environ["USE_OPENAI_EMBEDDING"] = "true"
+    sys.modules["openai"] = types.SimpleNamespace(
+        Embedding=types.SimpleNamespace(
+            create=lambda **kw: {"data": [{"embedding": [0.0] * 1536}]}
+        )
+    )
+    mod = reload_truth()
+    mod.qdrant = types.SimpleNamespace(upsert=lambda **kw: None)
+    uid = mod.store_sentence(
+        "hello",
+        {"well_id": "w", "source": "s", "tags": [], "timestamp": "t"},
+    )
+    assert isinstance(uid, str)
+    vec = mod.embed_text("hi")
+    assert len(vec) == 1536
+    os.environ.pop("USE_OPENAI_EMBEDDING")


### PR DESCRIPTION
## Summary
- allow truth_service to switch between sentence-transformers and OpenAI embeddings
- support new store_sentence helper and log insert success
- update test suite for OpenAI path and fix psycopg2 type hints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68503c10ecec83329c904876888a4657