### PR TITLE
[NOW] - enable file ingestor uploads via CORS

### DIFF
--- a/now_file_ingestor/main.py
+++ b/now_file_ingestor/main.py
@@ -8,12 +8,20 @@ from typing import Optional
 import redis
 import requests
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
 from loguru import logger
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from .utils import classify_filename, generate_file_path
 
 app = FastAPI(title="Genio NOW File Ingestor")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # update for specific domains in production
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 Instrumentator().instrument(app).expose(app)
 
 REDIS_HOST = os.getenv("REDIS_HOST", "genio_redis")

--- a/now_file_ingestor/tests/test_cors.py
+++ b/now_file_ingestor/tests/test_cors.py
@@ -1,0 +1,12 @@
+import sys
+import os
+from fastapi.middleware.cors import CORSMiddleware
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, ROOT)
+
+from now_file_ingestor.main import app
+
+
+def test_cors_middleware_present():
+    assert any(isinstance(m.cls, type) and m.cls is CORSMiddleware for m in app.user_middleware)


### PR DESCRIPTION
## Summary
- allow cross-origin requests in `now_file_ingestor` by adding CORS middleware
- verify middleware with unit test

## Testing
- `PYTHONPATH=$PWD:$PWD/shared pytest now_file_ingestor/tests/test_ingest_route.py now_file_ingestor/tests/test_cors.py`
- `PYTHONPATH=$PWD:$PWD/shared pytest` *(fails: ModuleNotFoundError in other services)*
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_685315e1012083328d8697c2cf9ee366